### PR TITLE
ARM: dts: r63350: Use default max brightness

### DIFF
--- a/arch/arm/boot/dts/qcom/oxygen/dsi-panel-tianma-r63350-1080p-video.dtsi
+++ b/arch/arm/boot/dts/qcom/oxygen/dsi-panel-tianma-r63350-1080p-video.dtsi
@@ -48,7 +48,7 @@
 		qcom,mdss-dsi-t-clk-pre = <0x30>;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		//qcom,mdss-brightness-max-level = <4095>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-on-command = [


### PR DESCRIPTION
* qcom,mdss-brightness-max-level has a default value of 255.
* This value is expected by lights HAL.
* Avoid the need to scale brightness value in lights HAL.